### PR TITLE
fog-prune 0.1.3 - Update for Chef 13 node attribute deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.1.3
+* Update for Chef 13 node attribute deprecations
+
 # v0.1.2
 * Add rackspace cross-reference support
 

--- a/lib/fog-prune/prune.rb
+++ b/lib/fog-prune/prune.rb
@@ -148,8 +148,8 @@ class FogPrune
 
   def filter_prunables_via_fog(nodes_to_prune)
     nodes_to_prune.map do |node|
-      if(node[:cloud] && node.cloud.provider)
-        if(respond_to?(check_method = "#{node.cloud.provider}_check"))
+      if(node[:cloud] && node[:cloud][:provider])
+        if(respond_to?(check_method = "#{node[:cloud][:provider]}_check"))
           send(check_method, node) ? node : nil
         end
       elsif(node[:prune_tag_time] && node[:ohai_time].nil?)
@@ -161,7 +161,7 @@ class FogPrune
   ## Checks
 
   def ec2_check(node)
-    aws_node = ec2_nodes.detect{|n| n.id == node.ec2.instance_id}
+    aws_node = ec2_nodes.detect{|n| n.id == node[:ec2][:instance_id]}
     unless(aws_node)
       debug "#{node.name} returned nil from aws"
     else

--- a/lib/fog-prune/version.rb
+++ b/lib/fog-prune/version.rb
@@ -1,3 +1,3 @@
 class FogPrune
-  VERSION = Gem::Version.new('0.1.2')
+  VERSION = Gem::Version.new('0.1.3')
 end


### PR DESCRIPTION
This cleans up a couple of places where the gem will fall over under chef 13 and higher.